### PR TITLE
Some new env variables to control additional configuration parameters

### DIFF
--- a/install/etc/cont-init.d/09-nginx
+++ b/install/etc/cont-init.d/09-nginx
@@ -10,7 +10,28 @@
   LLNG_HANDLER_PORT=${LLNG_HANDLER_PORT="2884"}
   WEB_USER=${WEB_USER:-admin}
   WEB_PASS=${WEB_PASS:-password}
-  
+  ENABLE_GZIP_COMPRESSION=${ENABLE_GZIP_COMPRESSION:-"true"}
+  GZIP_COMPRESSION_PARAMS='gzip on;               # enable gzip\n'
+  GZIP_COMPRESSION_PARAMS+='    gzip_http_version 1.1; # turn on gzip for http 1.1 and higher\n'
+  GZIP_COMPRESSION_PARAMS+='    gzip_disable “MSIE [1-6]\.(?!.*SV1)”;\n'
+  GZIP_COMPRESSION_PARAMS+='    gzip_disable "msie6";  # IE 6 had issues with gzip\n'
+  GZIP_COMPRESSION_PARAMS+='    gzip_comp_level 5;     # inc compresion level, and CPU usage\n'
+  GZIP_COMPRESSION_PARAMS+='    gzip_min_length 100;   # minimal weight to gzip file\n'
+  GZIP_COMPRESSION_PARAMS+='    gzip_proxied any;      # enable gzip for proxied requests (e.g. CDN)\n'
+  GZIP_COMPRESSION_PARAMS+='    gzip_buffers 16 8k;    # compression buffers (if we exceed this value, disk will be used instead of RAM)\n'
+  GZIP_COMPRESSION_PARAMS+='    gzip_vary on;          # add header Vary Accept-Encoding (more on that in Caching section)\n'
+  GZIP_COMPRESSION_PARAMS+='    # define files which should be compressed\n'
+  GZIP_COMPRESSION_PARAMS+='    gzip_types application/xml;\n'
+  GZIP_COMPRESSION_PARAMS+='    gzip_types text/plain;\n'
+  GZIP_COMPRESSION_PARAMS+='    gzip_types text/css;\n'
+  GZIP_COMPRESSION_PARAMS+='    gzip_types application/javascript;\n'
+  GZIP_COMPRESSION_PARAMS+='    gzip_types application/json;\n'
+  GZIP_COMPRESSION_PARAMS+='    gzip_types application/vnd.ms-fontobject;\n'
+  GZIP_COMPRESSION_PARAMS+='    gzip_types application/x-font-ttf;\n'
+  GZIP_COMPRESSION_PARAMS+='    gzip_types font/opentype;\n'
+  GZIP_COMPRESSION_PARAMS+='    gzip_types image/svg+xml;\n'
+  GZIP_COMPRESSION_PARAMS+='    gzip_types image/x-icon;\n'
+
 ### Map Authentication
   case "$AUTHENTICATION_TYPE" in
       "BASIC")
@@ -41,6 +62,13 @@
 ### Adjust NGINX Runtime Variables  
   sed -i -e "s/<UPLOAD_MAX_SIZE>/$UPLOAD_MAX_SIZE/g" /etc/nginx/nginx.conf
   sed -i -e "s/<PHP_TIMEOUT>/$PHP_TIMEOUT/g" /etc/nginx/conf.d/default.conf
+
+### Enable gzip compression
+if [ "$ENABLE_GZIP_COMPRESSION" = "TRUE" ] || [ "$ENABLE_GZIP_COMPRESSION" = "true" ]; then
+  sed -i -e "s|<GZIP_COMPRESSION>|$GZIP_COMPRESSION_PARAMS|g" /etc/nginx/conf.d/default.conf
+else
+  sed -i -e "s/<GZIP_COMPRESSION>/ /g" /etc/nginx/conf.d/default.conf
+fi
 
 ### Set Stage for Future Development and Production Purposes
    case "$STAGE" in

--- a/install/etc/cont-init.d/09-nginx
+++ b/install/etc/cont-init.d/09-nginx
@@ -10,6 +10,8 @@
   LLNG_HANDLER_PORT=${LLNG_HANDLER_PORT="2884"}
   WEB_USER=${WEB_USER:-admin}
   WEB_PASS=${WEB_PASS:-password}
+  WORKER_CONNECTIONS=${WORKER_CONNECTIONS:-"4096"}
+  WORKER_PROCESSES=${WORKER_PROCESSES:-"auto"}
   ENABLE_GZIP_COMPRESSION=${ENABLE_GZIP_COMPRESSION:-"true"}
   GZIP_COMPRESSION_PARAMS='gzip on;               # enable gzip\n'
   GZIP_COMPRESSION_PARAMS+='    gzip_http_version 1.1; # turn on gzip for http 1.1 and higher\n'
@@ -62,6 +64,8 @@
 ### Adjust NGINX Runtime Variables  
   sed -i -e "s/<UPLOAD_MAX_SIZE>/$UPLOAD_MAX_SIZE/g" /etc/nginx/nginx.conf
   sed -i -e "s/<PHP_TIMEOUT>/$PHP_TIMEOUT/g" /etc/nginx/conf.d/default.conf
+  sed -i -e "s/<WORKER_CONNECTIONS>/$WORKER_CONNECTIONS/g" /etc/nginx/nginx.conf
+  sed -i -e "s/<WORKER_PROCESSES>/$WORKER_PROCESSES/g" /etc/nginx/nginx.conf
 
 ### Enable gzip compression
 if [ "$ENABLE_GZIP_COMPRESSION" = "TRUE" ] || [ "$ENABLE_GZIP_COMPRESSION" = "true" ]; then

--- a/install/etc/cont-init.d/20-php-fpm
+++ b/install/etc/cont-init.d/20-php-fpm
@@ -65,7 +65,8 @@
   PHP_ENABLE_ZIP=${PHP_ENABLE_ZIP:-"FALSE"}
   PHP_ENABLE_ZLIB=${PHP_ENABLE_ZLIB:-"TRUE"}
   PHP_ENABLE_ZMQ=${PHP_ENABLE_ZMQ:-"FALSE"}
-
+  FPM_MAX_CHILDREN=${FPM_MAX_CHILDREN:-75}
+  FPM_MAX_REQUESTS=${FPM_MAX_REQUESTS:-500}
 
 ### Adjust PHP Runtime Variables
   sed -i -e "s/<APC_SHM_SIZE>/$APC_SHM_SIZE/g" /etc/php7/conf.d/apcu.ini
@@ -75,6 +76,10 @@
   sed -i -e "s/<PHP_TIMEOUT>/$PHP_TIMEOUT/g" /etc/php7/php.ini
   sed -i -e "s/<UPLOAD_MAX_SIZE>/$UPLOAD_MAX_SIZE/g" /etc/php7/php-fpm.conf
   sed -i -e "s/<UPLOAD_MAX_SIZE>/$UPLOAD_MAX_SIZE/g" /etc/php7/php.ini
+
+### FPM Runtime Variables
+  sed -i -e "s/<MAX_CHILDREN>/$FPM_MAX_CHILDREN/g" /etc/php7/php-fpm.conf
+  sed -i -e "s/<MAX_REQUESTS>/$FPM_MAX_REQUESTS/g" /etc/php7/php-fpm.conf
 
 ### Disable Modules
   if [ "$OPCACHE_MEM_SIZE" = "0" ]; then

--- a/install/etc/nginx/conf.d/default.conf
+++ b/install/etc/nginx/conf.d/default.conf
@@ -41,18 +41,20 @@
     location ~* /(?:uploads|files)/.*\.php$ {
    	deny all;
     }
-    
+
     location ~* \.(jpg|jpeg|gif|png|css|js|ico|xml)$ {
         access_log        on;
         log_not_found     on;
         expires           360d;
-    }    
+    }
+
+    <GZIP_COMPRESSION>
 
     ## Block SQL injections
     location ~* union.*select.*\( { access_log /www/logs/nginx/blocked.log blocked; deny all; }
     location ~* union.*all.*select.* { access_log /www/logs/nginx/blocked.log blocked; deny all; }
     location ~* concat.*\( { access_log /www/logs/nginx/blocked.log blocked; deny all; }
-    
+
     ## Block common exploits
     location ~* (<|%3C).*script.*(>|%3E) { access_log /www/logs/nginx/blocked.log blocked; deny all; }
     location ~* base64_(en|de)code\(.*\) { access_log /www/logs/nginx/blocked.log blocked; deny all; }

--- a/install/etc/nginx/nginx.conf
+++ b/install/etc/nginx/nginx.conf
@@ -4,9 +4,9 @@ daemon off;
 error_log /www/logs/nginx/error.log warn;
 pid /var/run/nginx.pid;
 
-worker_processes  auto;
+worker_processes  <WORKER_PROCESSES>;
 events {
-    worker_connections  4096;
+    worker_connections  <WORKER_CONNECTIONS>;
 }
 
 http {

--- a/install/etc/nginx/nginx.conf
+++ b/install/etc/nginx/nginx.conf
@@ -15,6 +15,7 @@ http {
   include    /etc/nginx/fastcgi.conf;
   default_type application/octet-stream;
   tcp_nopush   on;
+  tcp_nodelay  on;
   client_body_temp_path /tmp/nginx/body 1 2;
   fastcgi_temp_path /tmp/nginx/fastcgi_temp 1 2;
   

--- a/install/etc/php7/php-fpm.conf
+++ b/install/etc/php7/php-fpm.conf
@@ -10,12 +10,12 @@ listen.group = www-data
 pm = ondemand
 
 ; Total RAM dedicated to the web server / Max child process size
-pm.max_children = 75
+pm.max_children = <MAX_CHILDREN>
 pm.status_path = /php-fpm_status
 ping.path = /ping
 
 pm.process_idle_timeout = 10s
-pm.max_requests = 500
+pm.max_requests = <MAX_REQUESTS>
 ;chdir = /www/html
 php_flag[display_errors] = on
 php_admin_value[memory_limit] = <PHP_MEMORY_LIMIT>


### PR DESCRIPTION
Hi David,

This PR adds the following new env variables to configure additional nginx and php-fpm parameters:

* _ENABLE_GZIP_COMPRESSION=(true|false)_: Enables gzip compression. Default is true.
* _WORKER_PROCESSES_: to set nginx worker_processes parameter. Default is _auto_.
* _WORKER_CONNECTIONS_: to set nginx worker_connections parameter. Default is 4096.
* _FPM_MAX_CHILDREN_: to set php-fpm worker_processes. Default is 75.
* _FPM_MAX_REQUESTS_: to set php-fpm worker_requests. Default is 500.

Also I added nginx _tcp_nodelay_ nginx option as recommended [here](https://thoughts.t37.net/nginx-optimization-understanding-sendfile-tcp-nodelay-and-tcp-nopush-c55cdd276765).

Also, I think the child images shouldn't include their own copy of the configuration files (like nginx/conf.d/default.conf) and instead rely on the available env variables. If they are not enough the can ask for more variables to be added, or create their own custom image that includes their own custom config files can be a better approach.