### PR TITLE
Fixed typo in 20-php-fpm

### DIFF
--- a/install/assets/defaults/20-php-fpm
+++ b/install/assets/defaults/20-php-fpm
@@ -46,7 +46,7 @@ if [ "${PHP_ENABLE_REDIS,,}" = "true" ] ; then
     PHP_ENABLE_IGBINARY=TRUE
 fi
 
-if [ "${PHP_ENABLE_MEMCACHED,,}" = "true" ; then
+if [ "${PHP_ENABLE_MEMCACHED,,}" = "true"] ; then
     PHP_ENABLE_IGBINARY=TRUE
     PHP_ENABLE_MSGPACK=TRUE
 fi


### PR DESCRIPTION
In 73054eed8324aaa1cafd643154af72d976ec2f94 there is typo