### PR TITLE
Added support for debugging with PhpStorm

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,8 @@ Enable extensions by using the PHP extension name ie redis as `PHP_ENABLE_REDIS=
 To enable all extensions in image use `PHP_KITCHENSINK=TRUE`. Head inside the image and see what extensions are available by typing `php-ext list all`
 
 #### Debug Options
-To enable XDebug set `PHP_ENABLE_XDEBUG=TRUE`. Visit the [PHP XDebug Documentation](https://xdebug.org/docs/all_settings#remote_connect_back) to understand what these options mean.
+To enable XDebug set `PHP_ENABLE_XDEBUG=TRUE`. Visit the [PHP XDebug Documentation](https://xdebug.org/docs/all_settings#remote_connect_back) to understand what these options mean. 
+If you debug a PHP project in PHPStorm, you need to set server name using `PHP_IDE_CONFIG` to the same value as set in PHPStorm. Usual value is localhost, i.e. `PHP_IDE_CONFIG="serverName=localhost"`.
 
 For Xdebug 2 (php <= 7.1) you should set:
 | Parameter                            | Description                                |

--- a/install/assets/defaults/20-php-fpm
+++ b/install/assets/defaults/20-php-fpm
@@ -56,7 +56,7 @@ if [ "${PHP_ENABLE_REDIS,,}" = "true" ] ; then
     PHP_ENABLE_IGBINARY=TRUE
 fi
 
-if [ "${PHP_ENABLE_MEMCACHED,,}" = "true"] ; then
+if [ "${PHP_ENABLE_MEMCACHED,,}" = "true" ] ; then
     PHP_ENABLE_IGBINARY=TRUE
     PHP_ENABLE_MSGPACK=TRUE
 fi

--- a/install/etc/cont-init.d/20-php-fpm
+++ b/install/etc/cont-init.d/20-php-fpm
@@ -102,6 +102,14 @@ if [ ! -f "/tmp/.container/container-restart" ] ; then
   sed -i -e "s#post_max_size = .*#post_max_size = ${PHP_UPLOAD_MAX_SIZE}#g" /assets/php-fpm/cli/php.ini
   sed -i -e "s#upload_max_filesize = .*#upload_max_filesize = ${PHP_UPLOAD_MAX_SIZE}#g" /assets/php-fpm/cli/php.ini
 
+  if [[ ! -z "${PHP_IDE_CONFIG}" ]]; then
+	if [[ "${PHP_IDE_CONFIG}" = \"* ]] || [[ "${PHP_IDE_CONFIG}" = \'* ]] ; then
+	  echo -e "env[PHP_IDE_CONFIG] = ${PHP_IDE_CONFIG}\n" >> /assets/php-fpm/fpm/php-fpm.conf
+	else
+	  echo -e "env[PHP_IDE_CONFIG] = \"${PHP_IDE_CONFIG}\"\n" >> /assets/php-fpm/fpm/php-fpm.conf
+	fi
+  fi
+
   sed -i "/access.format=/d" /assets/php-fpm/fpm/php-fpm.conf
 
   case "${PHP_LOG_ACCESS_FORMAT,,}" in


### PR DESCRIPTION
When using PhpStorm for debugging, it is necessary to set the env variable `PHP_IDE_CONFIG ` so that it matches the setting in PhpStorm, otherwise the correct mapping of the debugger to lines of source code does not work.

php-fpm does not automatically take the env variables from container so this needs to be added manually if it is set.