### PR TITLE
Fix llng_auth_request config empty params

### DIFF
--- a/install/assets/functions/20-php-fpm
+++ b/install/assets/functions/20-php-fpm
@@ -31,7 +31,7 @@ phpfpm_bootstrap() {
 phpfpm_configure_authentication() {
     if [ "${NGINX_AUTHENTICATION_TYPE,,}" = "llng" ]; then
         print_notice "Adding LLNG Authentication parameters to nginx configuration"
-        header_num=$(printenv | sort | grep -c '\NGINX_AUTHENTICATION_LLNG_ATTRIBUTE.*')
+        header_num=$(printenv | sort | grep -c '^NGINX_AUTHENTICATION_LLNG_ATTRIBUTE.*')
         for ((i = 1; i <= header_num; i++)); do
             headers=NGINX_AUTHENTICATION_LLNG_ATTRIBUTE${i}
             IFS=',' read -r -a array <<<"${!headers}"


### PR DESCRIPTION
Hi @tiredofit,

I noticed that you have the same code/error as discussed in [nginx PR #17](https://github.com/tiredofit/docker-nginx/pull/17) in the php-fpm image. While the php-fpm image did rebuild as you said, the fix to the nginx image was then replaced by the same issue in the php-fpm one.

I've applied the same patch as before. However, given the nature of your layered approach with your nginx image as the base for the php-fpm one, does duplicating this code allow additional flexibility/features? Would the solution be to just remove that function/block [here](https://github.com/tiredofit/docker-nginx-php-fpm/blob/main/install/assets/functions/20-php-fpm#L31) from the php-fpm image if it's functionality is already covered by the nginx image now? Basically, while the same tweak (`\` --> `^`) works, maybe this PR isn't the approach and maybe there's an opportunity to de-duplicate? 

I look forward to your thoughts on this option and any context you can provide for the duplication of this function.